### PR TITLE
Fix two bugs preventing application startup on Linux

### DIFF
--- a/src/audio/mixer/Mixer.cpp
+++ b/src/audio/mixer/Mixer.cpp
@@ -4423,6 +4423,7 @@ bool Mixer::connectAudioHardwareInputToVacantInput(
             }
         }
     }
+    return false;
 }
 
 Mixer::DisconnectTask::DisconnectTask(Mixer& mixer, const ade::EdgeHandle& edgeHandle):

--- a/src/event/EventHandler.cpp
+++ b/src/event/EventHandler.cpp
@@ -228,7 +228,7 @@ void EventHandler::onOpenMainWindow()
     if(!errors.empty())
     {
         auto errorString = errors.front();
-        for(auto it = errorString.begin() + 1; it != errorString.end(); ++it)
+        for(auto it = errors.begin() + 1; it != errors.end(); ++it)
         {
             errorString.append(u'\n');
             errorString.append(*it);


### PR DESCRIPTION
- Add missing return statement in Mixer::connectAudioHardwareInputToVacantInput() which caused a compilation error with GCC 15's -Werror=return-type

- Fix iterator bug in EventHandler::onOpenMainWindow() where the loop incorrectly iterated over characters of errorString instead of the errors collection, causing a crash due to iterator invalidation when the string was modified during iteration